### PR TITLE
Update send_nogui.py

### DIFF
--- a/send_nogui.py
+++ b/send_nogui.py
@@ -83,7 +83,7 @@ except IndexError:
 try:
     openfield_input = sys.argv[4]
 except IndexError:
-    open_field = input("Enter openfield data (message): ")
+    openfield_input = input("Enter openfield data (message): ")
 
 # hardfork fee display
 fee = '%.8f' % float(0.01 + (float(len(openfield_input)) / 100000) + int(keep_input))  # 0.01 dust


### PR DESCRIPTION
`open_field = input("Enter openfield data (message): ")` changed to `openfield_input = input("Enter openfield data (message): ")` in order to prevent this error from happening:
```
Traceback (most recent call last):
  File "send_nogui.py", line 89, in <module>
    fee = '%.8f' % float(0.01 + (float(len(openfield_input)) / 100000) + int(keep_input))  # 0.01 dust
NameError: name 'openfield_input' is not defined
```