### PR TITLE
Fix an error that happened when closing the wallet on Linux

### DIFF
--- a/wallet.py
+++ b/wallet.py
@@ -1357,4 +1357,5 @@ image = Label(f2, image=logo).grid(pady=25, padx=50, sticky=N)
 refresh_auto()
 root.mainloop()
 
-os.remove(tempFile)
+if "posix" not in os.name:
+    os.remove(tempFile)


### PR DESCRIPTION
The last line of `wallet.py` caused an unhandled exception when running on Linux, and possibly on other POSIX systems. It tried to delete a temporary icon file used on Windows, I put a check before deleting to avoid the issue.