### PR TITLE
Set reuseaddr=True to enable the server to be restarted more quickly.

### DIFF
--- a/node.py
+++ b/node.py
@@ -2569,6 +2569,7 @@ if __name__ == "__main__":
             # Port 0 means to select an arbitrary unused port
             HOST, PORT = "0.0.0.0", int(port)
 
+            ThreadedTCPServer.allow_reuse_address = True
             server = ThreadedTCPServer((HOST, PORT), ThreadedTCPRequestHandler)
             ip, port = server.server_address
 


### PR DESCRIPTION
Without this fix, one has to wait a few minutes before the Bismuth node can be restarted after you kill it.  Setting reuseaddr=True enables faster restart, which should be good for the network as well as people's sanity.