### PR TITLE
Blocking sockets (Test)

### DIFF
--- a/connections.py
+++ b/connections.py
@@ -1,156 +1,51 @@
-import select, json, platform, time,sys
+import select, json, platform, time, sys
+import socket
 
-def send(sdef, data, slen):
-    sdef.setblocking(0)
+# Logical timeout
+LTIMEOUT = 45
+# Fixed header length
+SLEN = 10
+
+
+"""
+    Test with simplified blocking sockets
+"""
+
+def send(sdef, data, slen=SLEN):
     # Make sure the packet is sent in one call
+    sdef.settimeout(LTIMEOUT)
     sdef.sendall(str(len(str(json.dumps(data)))).encode("utf-8").zfill(slen)+str(json.dumps(data)).encode("utf-8"))
-
-if "Linux" in platform.system():
-    READ_OR_ERROR = select.POLLIN | select.POLLPRI | select.POLLHUP | select.POLLERR | select.POLLNVAL
-    #READ_ONLY = select.POLLIN | select.POLLPRI
-
-    def receive(sdef, slen):
-        try:
-            sdef.setblocking(0)
-            poller = select.poll()
-            poller.register(sdef, READ_OR_ERROR)
-            ready = False
-            while not ready:
-                ready = poller.poll(60000) # timeout is in ms
-            fd, flag = ready[0]
-            if (flag & (select.POLLIN|select.POLLPRI)):
-                data = sdef.recv(slen)
-                if not data:
-                    # POLLIN and POLLHUP are not exclusive. We can have both.
-                    raise RuntimeError("Socket EOF")
-                data = int(data)  # receive length
-            elif (flag & (select.POLLERR | select.POLLHUP | select.POLLNVAL)):
-                raise RuntimeError("Socket error {}".format(flag))
-            else:
-                raise RuntimeError("Socket Unexpected Error")
-            chunks = []
-            bytes_recd = 0
-            while bytes_recd < data:
-                ready = False
-                while not ready:
-                    ready = poller.poll(60000)
-                fd, flag = ready[0]
-                if (flag & (select.POLLIN|select.POLLPRI)):
-                    chunk = sdef.recv(min(data - bytes_recd, 2048))
-                    if not chunk:
-                        raise RuntimeError("Socket EOF")
-                    chunks.append(chunk)
-                    bytes_recd = bytes_recd + len(chunk)
-                elif (flag & (select.POLLERR | select.POLLHUP | select.POLLNVAL)):
-                    raise RuntimeError("Socket Error {}".format(flag))
-                else:
-                    raise RuntimeError("Socket Unexpected Error")
-
-            poller.unregister(sdef)
-            segments = b''.join(chunks).decode("utf-8")
-            return json.loads(segments)
-        except Exception as e:
-            """
-            exc_type, exc_obj, exc_tb = sys.exc_info()
-            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-            print(exc_type, fname, exc_tb.tb_lineno)
-            """
-            # Final cleanup
-            try:
-                poller.unregister(sdef)
-            except Exception as e2:
-                pass
-                #print ("Exception unregistering: {}".format(e2))
-            raise RuntimeError("Connections: {}".format(e))
+    # send will raise an error if socket is broken
 
 
-else:
-
-    def receive(sdef, slen):
-        sdef.setblocking(0)
-        ready = select.select([sdef], [], [], 30)
-        if ready[0]:
-            try:
-                data = int(sdef.recv(slen))  # receive length
-                #print ("To receive: {}".format(data))
-            except:
-                raise RuntimeError("Connection closed by the remote host") #do away with the invalid literal for int
-
-        else:
-            raise RuntimeError("Socket timeout")
-
+def receive(sdef, slen=SLEN):
+    sdef.settimeout(LTIMEOUT)
+    try:
+        data = sdef.recv(slen)
+        if not data:
+            raise RuntimeError("Socket EOF")
+        data = int(data)  # receive length
+    except socket.timeout as e:
+            return "*"
+            # no message for timeout sec, ping will check the socket
+    try:
         chunks = []
         bytes_recd = 0
         while bytes_recd < data:
-            ready = select.select([sdef], [], [], 30)
-            if ready[0]:
-                chunk = sdef.recv(min(data - bytes_recd, 2048))
-                if not chunk:
-                    raise RuntimeError("Socket connection broken")
-                chunks.append(chunk)
-                bytes_recd = bytes_recd + len(chunk)
-            else:
-                 raise RuntimeError("Socket timeout")
-
+            chunk = sdef.recv(min(data - bytes_recd, 2048))
+            if not chunk:
+                raise RuntimeError("Socket EOF2")
+            chunks.append(chunk)
+            bytes_recd = bytes_recd + len(chunk)
+            
         segments = b''.join(chunks).decode("utf-8")
-        #print("Received segments: {}".format(segments))
-
         return json.loads(segments)
+    except Exception as e:
+        """
+        exc_type, exc_obj, exc_tb = sys.exc_info()
+        fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
+        print(exc_type, fname, exc_tb.tb_lineno)
+        """
 
-if "Linux" in platform.system():
-    READ_OR_ERROR = select.POLLIN | select.POLLPRI | select.POLLHUP | select.POLLERR | select.POLLNVAL
-    #READ_ONLY = select.POLLIN | select.POLLPRI 
+        raise RuntimeError("Connections: {}".format(e))
 
-    def receive(sdef, slen):
-        try:
-            sdef.setblocking(0) 
-            poller = select.poll()
-            poller.register(sdef, READ_OR_ERROR)
-            ready = False
-            while not ready:
-                ready = poller.poll(60000) # timeout is in ms
-            fd, flag = ready[0]
-            if (flag & (select.POLLIN|select.POLLPRI)):
-                data = sdef.recv(slen)
-                if not data:
-                    # POLLIN and POLLHUP are not exclusive. We can have both.
-                    raise RuntimeError("Socket EOF")
-                data = int(data)  # receive length
-            elif (flag & (select.POLLERR | select.POLLHUP | select.POLLNVAL)):     
-                raise RuntimeError("Socket error {}".format(flag))
-            else:
-                raise RuntimeError("Socket Unexpected Error")
-            chunks = []
-            bytes_recd = 0
-            while bytes_recd < data:
-                ready = False
-                while not ready:
-                    ready = poller.poll(60000)
-                fd, flag = ready[0]
-                if (flag & (select.POLLIN|select.POLLPRI)):
-                    chunk = sdef.recv(min(data - bytes_recd, 2048))
-                    if not chunk:
-                        raise RuntimeError("Socket EOF")
-                    chunks.append(chunk)
-                    bytes_recd = bytes_recd + len(chunk)
-                elif (flag & (select.POLLERR | select.POLLHUP | select.POLLNVAL)):       
-                    raise RuntimeError("Socket Error {}".format(flag))
-                else:
-                    raise RuntimeError("Socket Unexpected Error")
-
-            poller.unregister(sdef)
-            segments = b''.join(chunks).decode("utf-8")
-            return json.loads(segments)
-        except Exception as e:
-            """
-            exc_type, exc_obj, exc_tb = sys.exc_info()
-            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-            print(exc_type, fname, exc_tb.tb_lineno)
-            """
-            # Final cleanup
-            try:
-                poller.unregister(sdef)
-            except Exception as e2:
-                pass
-                #print ("Exception unregistering: {}".format(e2))
-            raise RuntimeError("Connections: {}".format(e))


### PR DESCRIPTION
Test with blocking sockets.

As each socket lies in its own thread, we can simplify the design, and use the very same code for both Win and Linux.
This one also relies on the "ping" command from pr #150.

To be tested more thoroughly, but at first sight, this works as well as the complicated non blocking version.