### PR TITLE
More tolerant handling of config file

### DIFF
--- a/options.py
+++ b/options.py
@@ -1,76 +1,44 @@
 import os.path as path
 
-class Get:
-    def read(self):
-        if not path.exists("config_custom.txt"):
-            lines = [line.rstrip('\n') for line in open('config.txt')]
-        else:
-            lines = [line.rstrip('\n') for line in open('config_custom.txt')]
 
-        for line in lines:
-            if "port=" in line:
-                self.port = line.lstrip('port=')
-            if "genesis=" in line:
-                self.genesis_conf = line.lstrip('genesis=')
-            if "verify=" in line:
-                self.verify_conf = int(line.lstrip('verify='))
-            if "version=" in line:
-                self.version_conf = line.lstrip('version=')
-            if "version_allow=" in line:
-                self.version_allow = line.lstrip('version_allow=').split(",")
-            if "thread_limit=" in line:
-                self.thread_limit_conf = int(line.lstrip('thread_limit='))
-            if "rebuild_db=" in line:
-                self.rebuild_db_conf = int(line.lstrip('rebuild_db='))
-            if "debug=" in line:
-                self.debug_conf = int(line.lstrip('debug='))
-            if "purge=" in line:
-                self.purge_conf = int(line.lstrip('purge='))
-            if "pause=" in line:
-                self.pause_conf = line.lstrip('pause=')
-            if "ledger_path=" in line:
-                self.ledger_path_conf = line.lstrip('ledger_path=')
-            if "hyper_path=" in line:
-                self.hyper_path_conf = line.lstrip('hyper_path=')
-            if "hyper_recompress=" in line:
-                self.hyper_recompress_conf = int(line.lstrip('hyper_recompress='))
-            if "full_ledger=" in line:
-                self.full_ledger_conf = int(line.lstrip('full_ledger='))
-            if "ban_threshold=" in line:
-                self.ban_threshold = int(line.lstrip('ban_threshold='))
-            if "tor=" in line:
-                self.tor_conf = int(line.lstrip('tor='))
-            if "debug_level=" in line:
-                self.debug_level_conf = line.lstrip('debug_level=')
-            if "allowed=" in line:
-                self.allowed_conf = line.lstrip('allowed=')
-            if "pool_ip=" in line:
-                self.pool_ip_conf = line.lstrip("pool_ip=")
-            if "miner_sync=" in line:
-                self.sync_conf = int(line.lstrip('miner_sync='))
-            if "mining_threads=" in line:
-                self.mining_threads_conf = line.lstrip('mining_threads=')
-            if "diff_recalc=" in line:
-                self.diff_recalc_conf = int(line.lstrip('diff_recalc='))
-            if "mining_pool=" in line:
-                self.pool_conf = int(line.lstrip('mining_pool='))
-            if "pool_address=" in line:
-                self.pool_address_conf = line.lstrip('pool_address=')
-            if "ram=" in line:
-                self.ram_conf = int(line.lstrip('ram='))
-            if "pool_percentage=" in line:
-                self.pool_percentage_conf = int(line.lstrip('pool_percentage='))
-            if "node_ip=" in line:
-                self.node_ip_conf = line.lstrip('node_ip=')
-            if "light_ip=" in line:
-                self.light_ip_conf = line.lstrip('light_ip=')
-            if "reveal_address=" in line:
-                self.reveal_address = line.lstrip('reveal_address=')
-            if "accept_peers=" in line:
-                self.accept_peers = line.lstrip('accept_peers=')
-            if "banlist=" in line:
-                self.banlist = line.lstrip('banlist=').split(",")
-            if "whitelist=" in line:
-                self.whitelist = line.lstrip('whitelist=').split(",")
-            if "nodes_ban_reset=" in line:
-                self.nodes_ban_reset = int(line.lstrip('nodes_ban_reset='))
+class Get:
+    
+    # "param_name":["type"] or "param_name"=["type","property_name"]
+    vars={"port":["str"],"genesis":["str","genesis_conf"],"verify":["int","verify_conf"],"version":["str","version_conf"],"version_allow":["list"],
+    "thread_limit":["int","thread_limit_conf"],"rebuild_db":["int","rebuild_db_conf"],"debug":["int","debug_conf"],"purge":["int","purge_conf"],
+    "pause":["str","pause_conf"],"ledger_path":["str","ledger_path_conf"],"hyper_path":["str","hyper_path_conf"],"hyper_recompress":["int","hyper_recompress_conf"],
+    "full_ledger":["int","full_ledger_conf"],"ban_threshold":["int"],"tor":["int","tor_conf"],"debug_level":["str","debug_level_conf"],"allowed":["str","allowed_conf"],
+    "pool_ip":["str","pool_ip_conf"],"miner_sync":["int","sync_conf"],"mining_threads":["str","mining_threads_conf"],"diff_recalc":["int","diff_recalc_conf"],
+    "mining_pool":["int","pool_conf"],"pool_address":["str","pool_address_conf"],"ram":["int","ram_conf"],"pool_percentage":["int","pool_percentage_conf"],
+    "node_ip":["str","node_ip_conf"],"light_ip":["str","light_ip_conf"],"reveal_address":["str"],"accept_peers":["str"],"banlist":["list"],"whitelist":["list"],
+    "nodes_ban_reset":["int"]
+    }
+ 
+    def load_file(self,filename):
+        print("Loading",filename)
+        for line in open(filename):
+            if '=' in line:
+                left,right = map(str.strip,line.rstrip("\n").split("="))
+                if not left in self.vars:
+                    # Warn for unknown param?
+                    continue
+                params = self.vars[left]
+                if params[0] == "int":
+                    right = int(right)
+                elif params[0] == "list":
+                    right = [item.strip() for item in right.split(",")]
+                else:
+                    # treat as "str"
+                    pass 
+                if len(params)>1:
+                    # deal with properties that do not match the config name.
+                    left = params[1]
+                setattr(self,left,right)                
+        print(self.__dict__)           
+                    
+    def read(self):
+        # first of all, load from default config so we have all needed params
+        self.load_file("config.txt")
+        # then override with optional custom config
+        if path.exists("config_custom.txt"):
+            self.load_file("config_custom.txt")


### PR DESCRIPTION
Default code is strict on config file format (no space around the "=" sign for instance), thus error prone for the users.

This version:
- Keeps compatibility with other current code
- Doesn't make use of duplicate code
- Allow spaces around settings or "=" sign
- Allow for different settings types (str, int and list, can be extended)
- One single dict to config at the top, to add or edit params
- By default, uses property name = config name, but in order to keep compatibility, allows to rewrite the name of the option.

Then, more important:
- Uses default config file "config.txt" as a base for all settings
- Then overrides with params in "config_custom.txt" if it exists

Thus, 
- We are sure all new params from a newer version will always be present with their default value
- The user only needs to setup the params he wants to override, not all of them
- Simpler updates for team and users