### PR TITLE
Improve support for hidpi displays

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -33,3 +33,4 @@ whitelist=127.0.0.1
 nodes_ban_reset=5
 mempool_allowed=edf2d63cdf0b6275ead22c9e6d66aa8ea31dc0ccb367fad2e7c08a25,4edadac9093d9326ee4b17f869b14f1a2534f96f9c5d7b48dc9acaed
 terminal_output=no
+hidpi=no

--- a/options.py
+++ b/options.py
@@ -39,7 +39,8 @@ class Get:
         "whitelist":["list"],
         "nodes_ban_reset":["int"],
         "mempool_allowed": ["list"],
-        "terminal_output": ["str"]
+        "terminal_output": ["str"],
+        "hidpi": ["str"]
     }
  
     def load_file(self,filename):

--- a/wallet.py
+++ b/wallet.py
@@ -38,6 +38,7 @@ port = config.port
 light_ip = config.light_ip_conf
 version = config.version_conf
 terminal_output = config.terminal_output
+hidpi = config.hidpi
 
 if "testnet" in version:
     port = 2829
@@ -1149,6 +1150,9 @@ root.wm_title("Bismuth Light Wallet running on {}".format(light_ip))
 
 img = Image("photo", file="graphics/icon.gif")
 root.tk.call('wm', 'iconphoto', root._w, img)
+
+if hidpi == "yes":
+    root.tk.call("tk", "scaling", 2.0)
 
 password_var_enc = StringVar()
 password_var_con = StringVar()


### PR DESCRIPTION
The wallet was unreadable on hidpi displays; a config flag was added which makes the wallet usable on these displays.