### PR TITLE
Add default params

### DIFF
--- a/log.py
+++ b/log.py
@@ -14,7 +14,7 @@ def filter_status(record):
         return 0
 
 
-def log(logFile,level_input, terminal_output):
+def log(logFile, level_input="WARNING", terminal_output="no"):
     if level_input == "NOTSET":
         level = logging.NOTSET
     if level_input == "DEBUG":


### PR DESCRIPTION
When adding new parameters to a function, add defaults so it does not break other (possible third party) scripts depending on the same library.