### PR TITLE
Finer control over tried peers

### DIFF
--- a/peershandler.py
+++ b/peershandler.py
@@ -425,7 +425,8 @@ class Peers:
         """
         limit = time.time() + 12*60  # matches 2.5 tries :)
         remove = [client for client in self.tried if self.tried[client][1] > limit]
-        for client in remove: del self.tried[client]
+        for client in remove: 
+            del self.tried[client]
 
     def manager_loop(self, target=None):
         """Manager loop called every 30 sec. Handles maintenance"""


### PR DESCRIPTION
- reset "tried" dict when we successfully connect to a peer, so it can be tried again if it drops.
- progressive timeout for retries, depending on the retry count.
- 30 sec, 5 min, 15 min, then 30 minutes before retrying. (add_try)
- replaced lengthy "if" with a dedicated "can_connect_to" function that takes care of all the tests in order.
- includes a rewrite of the variability test
- Whitelisted peers are no more subject to the C class ip test.
- a few PEP fixes.